### PR TITLE
fix(winget): fix version command and add asset wait retry

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -67,7 +67,35 @@ jobs:
         shell: pwsh
         run: |
           Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          ./wingetcreate.exe --version
+          ./wingetcreate.exe version
+
+      - name: Wait for Release Assets
+        shell: pwsh
+        run: |
+          $url = "${{ steps.resolve.outputs.asset_url }}"
+          Write-Host "Waiting for asset to be available at: $url"
+          $maxRetries = 10
+          $retryCount = 0
+          $success = $false
+          
+          while ($retryCount -lt $maxRetries -and -not $success) {
+            try {
+              $response = Invoke-WebRequest -Uri $url -Method Head -ErrorAction Stop
+              if ($response.StatusCode -eq 200) {
+                $success = $true
+                Write-Host "Asset is available!"
+              }
+            } catch {
+              $retryCount++
+              Write-Host "Asset not ready yet (Attempt $retryCount/$maxRetries). Waiting 30s..."
+              Start-Sleep -Seconds 30
+            }
+          }
+          
+          if (-not $success) {
+            Write-Host "Error: Asset did not become available in time."
+            exit 1
+          }
 
       - name: Submit update (fallback to new)
         shell: pwsh


### PR DESCRIPTION
## Description
This PR fixes the failing `winget` workflow by addressing two main issues:

1.  **Corrected `wingetcreate` command**: Changed `./wingetcreate.exe --version` to `./wingetcreate.exe version`. The former returns exit code 1, which was causing the workflow to fail immediately.
2.  **Added "Wait for Release Assets" step**: There was a race condition where the `winget` workflow would trigger as soon as `semantic-release` created the GitHub Release, but before `goreleaser` had finished uploading the Windows `.zip` asset. The new step will wait up to 5 minutes for the asset to become available before proceeding.

### Impact
This will allow automated Winget submissions to work reliably after every new release.