### PR TITLE
chore: enable Renovate automerge for minor/patch/digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "automerge": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
Enables Renovate automerge for minor, patch, pin, and digest dependency updates. Major updates will still require manual approval.