### PR TITLE
fix(ci): serialize Automated Release runs to stop tag-collision races

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [ main ]
 
+# Serialize releases on main: overlapping runs (two pushes in quick
+# succession) race to compute/tag the same next version, and the loser
+# fails with "tag vX.Y.Z already exists" (tuna-os/bluefin-cli#78).
+# Queue instead of cancelling so every push still gets released.
+concurrency:
+  group: automated-release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write


### PR DESCRIPTION
## Summary
- `Automated Release` had no `concurrency` group, so two pushes to `main` close together could trigger overlapping `semantic-release` runs.
- Both compute the same next version from the same tag history; whichever pushes the tag second fails with `fatal: tag vX.Y.Z already exists` (observed for `v0.7.0` on 2026-07-11 — one run succeeded at 11:12:36, another failed at 11:12:39, another failed again at 11:58:00).
- Added a `concurrency` group keyed on the ref with `cancel-in-progress: false`, so runs queue instead of racing — every push still gets released, just serialized.

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)