### PR TITLE
fix(release): winget token template crashed the v0.7.0 publish

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -106,7 +106,7 @@ brews:
       owner: tuna-os
       name: homebrew-tap
       branch: main
-      token: '{{ envOrDefault "HOMEBREW_TAP_TOKEN" "" }}'
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
     homepage: "https://github.com/tuna-os/bluefin-cli"
     description: "Make your terminal experience awesome — shell config, tool bundles, and theming for any OS"
@@ -127,7 +127,7 @@ scoops:
       owner: tuna-os
       name: scoop-bucket
       branch: main
-      token: '{{ envOrDefault "SCOOP_BUCKET_TOKEN" "" }}'
+      token: "{{ .Env.SCOOP_BUCKET_TOKEN }}"
     homepage: "https://github.com/tuna-os/bluefin-cli"
     description: "Make your terminal experience awesome — shell config, tool bundles, and theming for any OS"
     license: Apache-2.0
@@ -148,7 +148,7 @@ aurs:
     maintainers:
       - "TunaOS <noreply@github.com>"
     git_url: "ssh://aur@aur.archlinux.org/bluefin-cli-bin.git"
-    private_key: '{{ envOrDefault "AUR_KEY" "" }}'
+    private_key: "{{ .Env.AUR_KEY }}"
     skip_upload: '{{ if envOrDefault "AUR_KEY" "" }}auto{{ else }}true{{ end }}'
     commit_author:
       name: tunabot
@@ -179,7 +179,7 @@ winget:
       owner: microsoft
       name: winget-pkgs
       branch: "bluefin-cli-{{.Version}}"
-      token: '{{ envOrDefault "WINGET_TOKEN" "" }}'
+      token: "{{ .Env.WINGET_TOKEN }}"
       pull_request:
         enabled: true
         draft: false


### PR DESCRIPTION
goreleaser renders repository `token`/`private_key` fields in a restricted env-only template mode — `envOrDefault` is not available there. The winget pipe (whose secret exists) crashed the publish step of v0.7.0 after all 17 assets had uploaded; brews/scoops/aur carried the same landmine but were skip-gated.

Tokens now use plain `{{ .Env.X }}` (the workflow always exports the vars, empty when the secret is unset, and skip_upload gates those pipes off before tokens are used). `skip_upload` keeps `envOrDefault`, which runs in the full template context — verified by v0.7.0's logs showing those gates evaluating correctly.

Merging this cuts v0.7.1 with a clean publish including the winget PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fuq6ZMBXZFZKhr4tNvtSNa