### PR TITLE
refactor: single UI codepath + architecture docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# bluefin-cli — agent guide
+
+Make your terminal experience awesome on any OS (Linux, macOS, Windows, WSL).
+Go CLI + bubbletea v2 TUI. Read `CONTEXT.md` for the domain glossary and
+`docs/adr/` for why things are the way they are.
+
+## Build & test
+
+```bash
+go build ./...                    # vanilla variant
+go build -tags extra ./...        # plus variant (wallpapers, fonts, sunset…)
+go test -tags extra ./...         # cmd tests REQUIRE -tags extra
+go build -tags extra -o bluefin-cli .   # integration tests exec ./bluefin-cli from repo root
+scripts/tui-smoke.sh <binary>     # tmux end-to-end suite (15 assertions; runs in CI)
+```
+
+- Both build variants must compile before committing; CI gates on tests,
+  tui-smoke, gofmt, and golangci-lint.
+- Local quirk on this dev box: /tmp is noexec — use `GOTMPDIR=$PWD/tmp/gotmp go test …`
+  and build scratch binaries into `tmp/` (gitignored).
+
+## Landmines
+
+- **Braille sprite rows must be 100% braille chars** (blanks are U+2800, not
+  spaces): some fonts draw braille double-wide and mixed-width rows shear.
+  Same class of bug: never put East-Asian-ambiguous glyphs (✓ · ❯ ↑↓←→)
+  inside a bordered box — that's why huh forms use a left-bar style.
+- **Anything that prints or blocks must run in `app.RunnerScreen`**, never
+  synchronously in a `View`/`Update` (glow queries the terminal and will
+  deadlock a synchronous capture).
+- **goreleaser repository `token`/`private_key` fields render env-only** —
+  no template functions (`envOrDefault` crashes there); `skip_upload` gets
+  the full template context.
+- Config tests must `viper.Reset()` when overriding HOME, or `Save()` writes
+  through the leaked config path into the user's real config.
+- Publisher `ids` filters in .goreleaser.yaml match **archive** IDs, not
+  build IDs.
+
+## Sprites
+
+Pixel art is generated, not hand-typed: `scripts/braillegen.py` (braille
+header dino) and the PixelCanvas grids in `internal/tui/app/game.go`
+(downsampled from the real Chrome sprite; see tmp workflow in the script).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# Domain glossary
+
+- **Shell experience / bling**: the curated set of modern CLI tools (eza,
+  bat, fzf, zoxide, atuin, starship, ugrep) wired into a user's shell rc
+  files. Toggled per shell (bash/zsh/fish/powershell) via `internal/shell`.
+- **Bundle**: a curated Brewfile of packages, fetched from
+  projectbluefin/common by category id (ai, cli, cncf, ide, k8s…);
+  installed with Homebrew (Linux/macOS) or winget (Windows).
+- **MOTD**: message-of-the-day printed on new terminals (image info + tip),
+  rendered with glow when available.
+- **Sunset switching**: Windows/WSL-only automation flipping light/dark
+  theme + wallpapers at sunrise/sunset from geocoded coordinates.
+- **Variants**: `bluefin-cli` (standard) and `bluefin-cli-plus`
+  (`-tags extra`: wallpapers, fonts, sunset). One codebase, two binaries.
+- **The shell (TUI)**: the persistent bubbletea program in
+  `internal/tui/app` — a stack of Screens under a shared header (gradient
+  wordmark + braille dino) and footer. Screen wrappers: MenuScreen,
+  FormScreen (huh v2 host), TextScreen, RunnerScreen (captured task log),
+  GameScreen (PixelCanvas easter egg).
+- **Legacy bridge (`RunExternal`)**: releases the terminal for a genuinely
+  external interactive program. Sole user: WSL→Windows sunset delegation.
+- **Delivery**: semantic-release drives goreleaser on pushes to main —
+  archives, deb/rpm, brew tap, scoop bucket, AUR, winget; one-liner
+  installers (install.sh/install.ps1) and checksum-verified self-update
+  (`internal/update`).

--- a/cmd/fonts.go
+++ b/cmd/fonts.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os/exec"
 
-	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
 	"github.com/tuna-os/bluefin-cli/internal/tui"
 )
@@ -32,44 +31,8 @@ var fontsCmd = &cobra.Command{
 	Short: "Install individual development fonts",
 	Long:  `Select and install individual development fonts from a curated list.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runFontsMenu()
+		return launchFlow(fontsFlow())
 	},
-}
-
-func runFontsMenu() error {
-	tui.ClearScreen()
-	tui.RenderHeader("Bluefin CLI", "Main Menu > Fonts")
-
-	opts := make([]huh.Option[string], 0, len(availableFonts))
-	for _, f := range availableFonts {
-		opts = append(opts, huh.NewOption(f.Name, f.Cask))
-	}
-
-	var selected []string
-	form := huh.NewForm(
-		huh.NewGroup(
-			huh.NewMultiSelect[string]().
-				Title("Select fonts to install").
-				Options(opts...).
-				Value(&selected),
-		),
-	).WithTheme(tui.AppTheme).WithKeyMap(tui.MenuKeyMap())
-
-	if err := form.Run(); err != nil {
-		return nil
-	}
-
-	if len(selected) == 0 {
-		fmt.Println(tui.InfoStyle.Render("No fonts selected."))
-		tui.Pause()
-		return nil
-	}
-
-	installFontCasks(selected)
-
-	err := maybeHandlePostFontInstall()
-	tui.Pause()
-	return err
 }
 
 // installFontCasks installs each font cask with brew, printing progress

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -2,13 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
-	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
 	"github.com/tuna-os/bluefin-cli/internal/env"
 	"github.com/tuna-os/bluefin-cli/internal/install"
 	"github.com/tuna-os/bluefin-cli/internal/tui"
+	"github.com/tuna-os/bluefin-cli/internal/tui/app"
 )
 
 var installCmd = &cobra.Command{
@@ -28,7 +27,7 @@ Or provide a path to a local Brewfile.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			return runBundlesMenu()
+			return launchFlow(app.Push(bundlesMenuScreen()))
 		}
 
 		return install.Bundle(args[0])
@@ -70,7 +69,7 @@ var installWallpapersCmd = &cobra.Command{
 			return maybeHandleWindowsThemePostInstall(cmd, args)
 		}
 
-		return runWallpapersMenu()
+		return launchFlow(wallpapersFlow())
 	},
 }
 
@@ -111,173 +110,9 @@ var bundleCategories = []bundleCategory{
 	{Label: "🐧 Full GNOME Desktop", ID: "full-desktop", Desc: "Complete desktop environment", LinuxOnly: true},
 }
 
-func runBundlesMenu() error {
-	for {
-		tui.ClearScreen()
-		tui.RenderHeader("Bluefin CLI", "Main Menu > Install Apps")
-
-		opts := make([]huh.Option[string], 0)
-		for _, cat := range bundleCategories {
-			if cat.LinuxOnly && (!install.IsLinux() || !install.IsGnome()) {
-				continue
-			}
-			opts = append(opts, huh.NewOption(cat.Label+" ❯", cat.ID))
-		}
-
-		var category string
-		form := huh.NewForm(
-			huh.NewGroup(
-				huh.NewSelect[string]().
-					Title("Select a category").
-					Options(opts...).
-					Value(&category),
-			),
-		).WithTheme(tui.AppTheme).WithKeyMap(tui.MenuKeyMap())
-
-		if err := form.Run(); err != nil {
-			if err == huh.ErrUserAborted {
-				return nil
-			}
-			return fmt.Errorf("form error: %w", err)
-		}
-
-		if err := runPackageMenu(category); err != nil {
-			if err == huh.ErrUserAborted {
-				continue
-			}
-			fmt.Println(tui.ErrorStyle.Render(fmt.Sprintf("Error: %v", err)))
-			tui.Pause()
-		}
-	}
-}
-
 // runPackageMenu shows a per-category multi-select with installed packages pre-checked,
 // then diffs and applies installs/uninstalls with confirmation. Works on both Unix (brew)
 // and Windows (winget).
-func runPackageMenu(bundleName string) error {
-	tui.ClearScreen()
-
-	var categoryLabel string
-	for _, cat := range bundleCategories {
-		if cat.ID == bundleName {
-			categoryLabel = cat.Label
-			break
-		}
-	}
-	tui.RenderHeader("Bluefin CLI", "Install Apps > "+categoryLabel)
-
-	fmt.Println(tui.InfoStyle.Render("Loading packages..."))
-	pkgs, err := install.GetBundlePackages(bundleName)
-	if err != nil {
-		return fmt.Errorf("could not load bundle: %w", err)
-	}
-
-	pkgs = install.MarkInstalled(pkgs)
-
-	// Pre-populate selection with currently installed packages
-	preSelected := make([]string, 0)
-	for _, p := range pkgs {
-		if p.Installed {
-			preSelected = append(preSelected, p.ID)
-		}
-	}
-
-	opts := make([]huh.Option[string], 0, len(pkgs))
-	for _, p := range pkgs {
-		opts = append(opts, huh.NewOption(p.Name, p.ID))
-	}
-
-	selected := make([]string, len(preSelected))
-	copy(selected, preSelected)
-
-	tui.ClearScreen()
-	tui.RenderHeader("Bluefin CLI", "Install Apps > "+categoryLabel)
-
-	form := huh.NewForm(
-		huh.NewGroup(
-			huh.NewMultiSelect[string]().
-				Title("Select packages").
-				Description("Pre-checked = already installed. Space toggles, enter confirms.").
-				Options(opts...).
-				Value(&selected),
-		),
-	).WithTheme(tui.AppTheme).WithKeyMap(tui.MenuKeyMap())
-
-	if err := form.Run(); err != nil {
-		return err
-	}
-
-	// Diff: what changed vs pre-installed state
-	preSet := make(map[string]bool, len(preSelected))
-	for _, id := range preSelected {
-		preSet[id] = true
-	}
-	newSet := make(map[string]bool, len(selected))
-	for _, id := range selected {
-		newSet[id] = true
-	}
-
-	var toInstall, toRemove []install.Package
-	for _, p := range pkgs {
-		wasInstalled := preSet[p.ID]
-		isSelected := newSet[p.ID]
-		switch {
-		case isSelected && !wasInstalled:
-			toInstall = append(toInstall, p)
-		case !isSelected && wasInstalled:
-			toRemove = append(toRemove, p)
-		}
-	}
-
-	if len(toInstall) == 0 && len(toRemove) == 0 {
-		fmt.Println(tui.InfoStyle.Render("No changes selected."))
-		tui.Pause()
-		return nil
-	}
-
-	// Confirmation
-	tui.ClearScreen()
-	tui.RenderHeader("Bluefin CLI", "Install Apps > "+categoryLabel+" > Confirm")
-
-	if len(toInstall) > 0 {
-		fmt.Println(tui.SuccessStyle.Render("Will install:"))
-		for _, p := range toInstall {
-			fmt.Printf("  + %s\n", p.Name)
-		}
-	}
-	if len(toRemove) > 0 {
-		fmt.Println(tui.ErrorStyle.Render("Will uninstall:"))
-		for _, p := range toRemove {
-			fmt.Printf("  - %s\n", p.Name)
-		}
-	}
-	fmt.Println()
-
-	var confirmed bool
-	confirm := huh.NewForm(
-		huh.NewGroup(
-			huh.NewConfirm().
-				Title("Apply these changes?").
-				Value(&confirmed),
-		),
-	).WithTheme(tui.AppTheme).WithKeyMap(tui.ConfirmKeyMap())
-
-	if err := confirm.Run(); err != nil || !confirmed {
-		return nil
-	}
-
-	// Execute
-	tui.ClearScreen()
-	tui.RenderHeader("Bluefin CLI", "Install Apps > "+categoryLabel+" > Installing")
-
-	applyPackageChanges(toInstall, toRemove)
-
-	fmt.Println()
-	fmt.Println(tui.SuccessStyle.Render("✓ Done!"))
-	tui.Pause()
-	return nil
-}
-
 // applyPackageChanges installs and removes packages with the platform's
 // package manager, printing errors as it goes (used by both the legacy
 // flow and the native menu flow via the legacy bridge).
@@ -318,54 +153,4 @@ func applyPackageChanges(toInstall, toRemove []install.Package) {
 		}
 	}
 
-}
-
-func runWallpapersMenu() error {
-	tui.ClearScreen()
-	tui.RenderHeader("Bluefin CLI", "Main Menu > Wallpapers")
-	casks, err := install.GetWallpaperCasks()
-	if err != nil {
-		return fmt.Errorf("failed to discover wallpaper casks: %w", err)
-	}
-	if len(casks) == 0 {
-		return fmt.Errorf("no wallpaper casks found in ublue-os/tap")
-	}
-
-	opts := make([]huh.Option[string], 0, len(casks))
-	for _, c := range casks {
-		opts = append(opts, huh.NewOption(c, c))
-	}
-
-	var selected []string
-	wallpaperSelect := huh.NewMultiSelect[string]().
-		Title("Select wallpapers to install").
-		Description("Space toggles selections. Enter confirms. If none selected, Enter installs the highlighted item.").
-		Options(opts...).
-		Value(&selected)
-
-	form := huh.NewForm(
-		huh.NewGroup(
-			wallpaperSelect,
-		),
-	).WithTheme(tui.AppTheme).WithKeyMap(tui.MenuKeyMap())
-	if err := form.Run(); err != nil {
-		if err == huh.ErrUserAborted {
-			return nil
-		}
-		return fmt.Errorf("form error: %w", err)
-	}
-
-	if len(selected) == 0 {
-		hovered, ok := wallpaperSelect.Hovered()
-		if !ok || strings.TrimSpace(hovered) == "" {
-			return fmt.Errorf("no wallpapers selected")
-		}
-		selected = []string{hovered}
-	}
-
-	if err := install.InstallWallpaperCasks(selected); err != nil {
-		return err
-	}
-
-	return maybeHandleWindowsThemePostInstall(nil, selected)
 }

--- a/cmd/menu.go
+++ b/cmd/menu.go
@@ -58,6 +58,14 @@ func checkForUpdate() tea.Msg {
 	return app.ToastMsg{Text: fmt.Sprintf("⬆ %s available — run: %s", rel.TagName, hint)}
 }
 
+// launchFlow opens the interactive shell and immediately runs flow — used
+// by commands like `bluefin-cli fonts` so every interactive path shares the
+// native TUI (esc leads back to the Home menu).
+func launchFlow(flow tea.Cmd) error {
+	registerPaletteActions()
+	return app.Run(mainMenuScreen(), flow, checkForUpdate)
+}
+
 func mainMenuScreen() app.Screen {
 	return app.NewMenu("Home", nil, mainMenuItems, mainMenuSelect)
 }

--- a/cmd/menu_native.go
+++ b/cmd/menu_native.go
@@ -245,7 +245,7 @@ func advancedMenuScreen() app.Screen {
 			dark = "☀️  Dark Mode: Off"
 		}
 		return []app.MenuItem{
-			{Label: dark, Value: "toggle_dark", Desc: "Hint for legacy CLI output styling"},
+			{Label: dark, Value: "toggle_dark", Desc: "Color hint for plain CLI output"},
 			{Icon: "🎨", Label: "Flavor: " + viper.GetString("ui.flavor"), Value: "flavor",
 				Desc: "Cycle Catppuccin flavor (auto follows the terminal)"},
 		}

--- a/cmd/motd.go
+++ b/cmd/motd.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
 	"github.com/tuna-os/bluefin-cli/internal/motd"
-	"github.com/tuna-os/bluefin-cli/internal/shell"
 	"github.com/tuna-os/bluefin-cli/internal/tui"
+	"github.com/tuna-os/bluefin-cli/internal/tui/app"
 )
 
 var motdCmd = &cobra.Command{
@@ -17,7 +15,7 @@ var motdCmd = &cobra.Command{
 	Short: "Manage Message of the Day",
 	Long:  `Configure and display the Message of the Day (MOTD) with system info and tips.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runMotdMenu()
+		return launchFlow(app.Push(motdMenuScreen()))
 	},
 }
 
@@ -92,68 +90,4 @@ func init() {
 	motdCmd.AddCommand(motdToggleCmd)
 	motdCmd.AddCommand(motdShowCmd)
 	motdCmd.AddCommand(motdConfigCmd)
-}
-
-func runMotdMenu() error {
-	for {
-		tui.ClearScreen()
-		tui.RenderHeader("Bluefin CLI", "Main Menu > Shell > MOTD")
-
-		// Load config to check if MOTD is enabled
-		// Determine shell (fallback to bash if unknown, as this affects defaults)
-		currentShellPath := os.Getenv("SHELL")
-		currentShell := filepath.Base(currentShellPath)
-		if currentShell == "" || currentShell == "." {
-			currentShell = "bash"
-		}
-
-		cfg, err := shell.LoadConfig(currentShell)
-		if err != nil {
-			cfg = shell.DefaultConfig(currentShell)
-		}
-		isEnabled := cfg.IsEnabled("Motd")
-
-		// Build toggle label based on current state
-		toggleLabel := "Enable MOTD"
-		if isEnabled {
-			toggleLabel = "Disable MOTD"
-		}
-
-		var action string
-		if err := huh.NewForm(
-			huh.NewGroup(
-				huh.NewSelect[string]().
-					Title("MOTD – What do you want to do?").
-					Options(
-						huh.NewOption(toggleLabel, "toggle_motd"),
-						huh.NewOption("Show MOTD", "show"),
-						huh.NewOption("Exit to Shell Menu", "exit"),
-					).
-					Value(&action),
-			),
-		).WithTheme(tui.AppTheme).WithKeyMap(tui.MenuKeyMap()).Run(); err != nil {
-			return huh.ErrUserAborted
-		}
-
-		switch action {
-		case "toggle_motd":
-			cfg.SetEnabled("Motd", !isEnabled)
-			if err := shell.SaveConfig(cfg); err != nil {
-				return fmt.Errorf("failed to save config: %w", err)
-			}
-			if !isEnabled {
-				fmt.Println(tui.SuccessStyle.Render("✓ MOTD enabled"))
-			} else {
-				fmt.Println(tui.SuccessStyle.Render("✓ MOTD disabled"))
-			}
-			tui.Pause()
-		case "show":
-			if err := motd.Show(); err != nil {
-				return err
-			}
-			tui.Pause()
-		case "exit":
-			return nil
-		}
-	}
 }

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -2,17 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
-	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/tuna-os/bluefin-cli/internal/config"
 	"github.com/tuna-os/bluefin-cli/internal/env"
 	"github.com/tuna-os/bluefin-cli/internal/shell"
-	"github.com/tuna-os/bluefin-cli/internal/tui"
+	"github.com/tuna-os/bluefin-cli/internal/tui/app"
 )
 
 var shellCmd = &cobra.Command{
@@ -28,7 +23,7 @@ The Shell Experience provides:
 	Args: cobra.MaximumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			return runShellMenu()
+			return launchFlow(app.Push(shellMenuScreen()))
 		}
 
 		// Args provided
@@ -47,253 +42,8 @@ var shellConfigCmd = &cobra.Command{
 	Short: "Configure individual shell experience tools",
 	Long:  `Enable or disable specific shell experience components interactively.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return configureShellTools()
+		return launchFlow(app.Push(componentsFormScreen()))
 	},
-}
-
-func runShellMenu() error {
-	for {
-		tui.ClearScreen()
-		tui.RenderHeader("Bluefin CLI", "Main Menu > Shell")
-
-		currentShellPath := os.Getenv("SHELL")
-		currentShell := filepath.Base(currentShellPath)
-		if currentShell == "" || currentShell == "." {
-			if env.IsWindows() {
-				currentShell = "powershell"
-			} else {
-				currentShell = "bash"
-			}
-		}
-
-		status := shell.CheckStatus()
-		isEnabled := status[currentShell]
-		toggleLabel := fmt.Sprintf("🔄 Enable for current shell (%s)", currentShell)
-		if isEnabled {
-			toggleLabel = fmt.Sprintf("🔄 Disable for current shell (%s)", currentShell)
-		}
-
-		var action string
-		componentsLabel := "🔧 Configure Components ❯"
-		motdLabel := "📰 MOTD Settings ❯"
-		shellsLabel := "🐚 Other Shells ❯"
-		advancedLabel := "🎨 Advanced ❯"
-
-		if err := huh.NewForm(
-			huh.NewGroup(
-				huh.NewSelect[string]().
-					Title("Choose an option").
-					Options(
-						huh.NewOption(toggleLabel, "toggle_current"),
-						huh.NewOption(componentsLabel, "components"),
-						huh.NewOption(motdLabel, "motd"),
-						huh.NewOption(shellsLabel, "shells"),
-						huh.NewOption(advancedLabel, "advanced"),
-						huh.NewOption("Exit to Main Menu", "exit"),
-					).
-					Value(&action),
-			),
-		).WithTheme(tui.AppTheme).WithKeyMap(tui.MenuKeyMap()).Run(); err != nil {
-			return huh.ErrUserAborted
-		}
-
-		switch action {
-		case "toggle_current":
-			if err := shell.Toggle(currentShell, !isEnabled); err != nil {
-				return err
-			}
-			tui.Pause()
-		case "shells":
-			if err := shellShellsMenu(); err != nil {
-				return err
-			}
-		case "components":
-			if err := configureShellTools(); err != nil {
-				return err
-			}
-		case "motd":
-			if err := runMotdMenu(); err != nil {
-				return err
-			}
-		case "advanced":
-			if err := runAdvancedMenu(); err != nil {
-				return err
-			}
-		case "exit":
-			return nil
-		}
-	}
-}
-
-func shellShellsMenu() error {
-	tui.ClearScreen()
-	tui.RenderHeader("Bluefin CLI", "Main Menu > Shell > Shells")
-
-	status := shell.CheckStatus()
-	installedShells := shell.GetInstalledShells()
-
-	var selected []string
-	for _, s := range installedShells {
-		if status[s] {
-			selected = append(selected, s)
-		}
-	}
-
-	initialSelected := make(map[string]bool)
-	for _, sh := range selected {
-		initialSelected[sh] = true
-	}
-
-	// Build options dynamically based on installed shells
-	var options []huh.Option[string]
-	for _, s := range installedShells {
-		options = append(options, huh.NewOption(s, s))
-	}
-
-	if err := huh.NewForm(
-		huh.NewGroup(
-			huh.NewMultiSelect[string]().
-				Title("Manage other shells").
-				Description("Selected = ON, Deselected = OFF").
-				Options(options...).
-				Value(&selected),
-		),
-	).WithTheme(tui.AppTheme).WithKeyMap(tui.MenuKeyMap()).Run(); err != nil {
-		return huh.ErrUserAborted
-	}
-
-	finalSelected := make(map[string]bool)
-	for _, sh := range selected {
-		finalSelected[sh] = true
-	}
-
-	for _, shName := range installedShells {
-		wasEnabled := initialSelected[shName]
-		isEnabled := finalSelected[shName]
-
-		if wasEnabled != isEnabled {
-			if err := shell.Toggle(shName, isEnabled); err != nil {
-				return err
-			}
-			tui.Pause()
-		}
-	}
-	return nil
-}
-
-func configureShellTools() error {
-	tui.ClearScreen()
-	tui.RenderHeader("Bluefin CLI", "Main Menu > Shell > Components")
-
-	currentShellPath := os.Getenv("SHELL")
-	currentShell := filepath.Base(currentShellPath)
-	if currentShell == "" || currentShell == "." {
-		if env.IsWindows() {
-			currentShell = "powershell"
-		} else {
-			currentShell = "bash"
-		}
-	}
-
-	cfg, err := shell.LoadConfig(currentShell)
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	availableTools := shell.ToolsForShell(currentShell)
-
-	var selected []string
-	for _, tool := range availableTools {
-		if cfg.IsEnabled(tool.Name) {
-			selected = append(selected, tool.Name)
-		}
-	}
-
-	var options []huh.Option[string]
-	for _, tool := range availableTools {
-		label := fmt.Sprintf("%s (%s)", tool.Name, tool.Description)
-		options = append(options, huh.NewOption(label, tool.Name))
-	}
-
-	form := huh.NewForm(
-		huh.NewGroup(
-			huh.NewMultiSelect[string]().
-				Title("Select tools to enable").
-				Description("Uncheck to disable specific tools").
-				Options(options...).
-				Value(&selected),
-		),
-	).WithTheme(tui.AppTheme).WithKeyMap(tui.MenuKeyMap())
-
-	if err := form.Run(); err != nil {
-		if err == huh.ErrUserAborted {
-			return huh.ErrUserAborted
-		}
-		return fmt.Errorf("form error: %w", err)
-	}
-
-	newCfg := shell.DefaultConfig(currentShell)
-	selectedSet := make(map[string]bool)
-	for _, s := range selected {
-		selectedSet[s] = true
-	}
-
-	for _, tool := range availableTools {
-		newCfg.SetEnabled(tool.Name, selectedSet[tool.Name])
-	}
-
-	if err := shell.SaveConfig(newCfg); err != nil {
-		return fmt.Errorf("failed to save config: %w", err)
-	}
-
-	// Install any newly enabled tools
-	shell.InstallTools(currentShell, newCfg)
-
-	fmt.Println(tui.SuccessStyle.Render("Configuration saved! Tools installed/updated."))
-	tui.Pause()
-	return nil
-}
-
-func runAdvancedMenu() error {
-	tui.ClearScreen()
-	tui.RenderHeader("Bluefin CLI", "Main Menu > Shell > Advanced")
-
-	isDark := viper.GetBool("ui.dark_mode")
-	darkModeLabel := "🌙 Dark Mode: On"
-	if !isDark {
-		darkModeLabel = "☀️  Dark Mode: Off"
-	}
-
-	var action string
-	if err := huh.NewForm(
-		huh.NewGroup(
-			huh.NewSelect[string]().
-				Title("Advanced Settings").
-				Options(
-					huh.NewOption(darkModeLabel, "toggle_dark"),
-					huh.NewOption("Back", "exit"),
-				).
-				Value(&action),
-		),
-	).WithTheme(tui.AppTheme).WithKeyMap(tui.MenuKeyMap()).Run(); err != nil {
-		return huh.ErrUserAborted
-	}
-
-	if action == "toggle_dark" {
-		viper.Set("ui.dark_mode", !isDark)
-		if err := config.Save(); err != nil {
-			fmt.Println(tui.ErrorStyle.Render("Failed to save setting: " + err.Error()))
-			tui.Pause()
-		} else {
-			state := "Dark"
-			if isDark {
-				state = "Light"
-			}
-			fmt.Println(tui.SuccessStyle.Render("✓ Switched to " + state + " mode"))
-			tui.Pause()
-		}
-	}
-	return nil
 }
 
 func init() {

--- a/cmd/starship.go
+++ b/cmd/starship.go
@@ -1,12 +1,8 @@
 package cmd
 
 import (
-	"fmt"
-
-	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
 	"github.com/tuna-os/bluefin-cli/internal/starship"
-	"github.com/tuna-os/bluefin-cli/internal/tui"
 )
 
 var starshipCmd = &cobra.Command{
@@ -14,7 +10,7 @@ var starshipCmd = &cobra.Command{
 	Short: "Manage Starship prompt themes",
 	Long:  `Install, configure, and customize Starship prompt themes.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runStarshipMenu()
+		return launchFlow(starshipFlow())
 	},
 }
 
@@ -26,7 +22,7 @@ var starshipThemeCmd = &cobra.Command{
 		if len(args) > 0 {
 			return starship.ApplyTheme(args[0])
 		}
-		return runThemeSelector()
+		return launchFlow(starshipFlow())
 	},
 }
 
@@ -43,48 +39,4 @@ func init() {
 	rootCmd.AddCommand(starshipCmd)
 	starshipCmd.AddCommand(starshipThemeCmd)
 	starshipCmd.AddCommand(starshipInstallCmd)
-}
-func runStarshipMenu() error {
-	// Ensure Starship is installed
-	if err := starship.Install(); err != nil {
-		return err
-	}
-	return runThemeSelector()
-}
-
-func runThemeSelector() error {
-	tui.ClearScreen()
-	tui.RenderHeader("Bluefin CLI", "Main Menu > Starship Theme")
-	var selectedTheme string
-
-	form := huh.NewForm(
-		huh.NewGroup(
-			huh.NewSelect[string]().
-				Title("Choose a Starship theme").
-				Description("Select a preset theme for your terminal prompt").
-				Options(
-					huh.NewOption("Nerd Font Symbols", "nerd-font-symbols"),
-					huh.NewOption("No Runtime Versions", "no-runtime-versions"),
-					huh.NewOption("Plain Text Symbols", "plain-text-symbols"),
-					huh.NewOption("Pure Preset", "pure-preset"),
-					huh.NewOption("Tokyo Night", "tokyo-night"),
-					huh.NewOption("Gruvbox Rainbow", "gruvbox-rainbow"),
-					huh.NewOption("Catppuccin Powerline", "catppuccin-powerline"),
-					huh.NewOption("Jetpack", "jetpack"),
-					huh.NewOption("No Empty Icons", "no-empty-icons"),
-					huh.NewOption("No Nerd Font", "no-nerd-font"),
-					huh.NewOption("Pastel Powerline", "pastel-powerline"),
-				).
-				Value(&selectedTheme),
-		),
-	).WithTheme(tui.AppTheme).WithKeyMap(tui.MenuKeyMap())
-
-	if err := form.Run(); err != nil {
-		if err == huh.ErrUserAborted {
-			return nil
-		}
-		return fmt.Errorf("form error: %w", err)
-	}
-
-	return starship.ApplyTheme(selectedTheme)
 }

--- a/docs/adr/0001-native-tui-shell.md
+++ b/docs/adr/0001-native-tui-shell.md
@@ -1,0 +1,23 @@
+# ADR 0001: One persistent TUI shell, native screens only
+
+**Status**: accepted (2026-07)
+
+## Context
+The menu system grew organically as independent huh `form.Run()` calls that
+cleared and took over the terminal; navigation state, headers, and theming
+were rebuilt ad hoc per flow, and drill-down/back behavior was inconsistent.
+
+## Decision
+One long-lived bubbletea v2 program (`internal/tui/app`) hosts a stack of
+`Screen`s (k9s-style push/pop). Every interactive flow renders inside it via
+four wrappers: MenuScreen (lists), FormScreen (embedded huh v2 forms),
+TextScreen (read-only, scrollable), RunnerScreen (tasks that print — output
+is captured by swapping os.Stdout to a pipe; the renderer keeps its own fd).
+Interactive CLI commands (`bluefin-cli fonts`…) launch the same shell at the
+right screen, so there is exactly one UI codepath. `RunExternal` (tea.Exec)
+survives only for launching genuinely external interactive programs.
+
+## Consequences
+Consistent chrome, theming, and keybindings everywhere; flows are unit-
+testable as models (no pty). Anything that prints or blocks MUST go through
+RunnerScreen — synchronous capture deadlocks (glow terminal queries).

--- a/docs/adr/0002-terminal-graphics-strategy.md
+++ b/docs/adr/0002-terminal-graphics-strategy.md
@@ -1,0 +1,21 @@
+# ADR 0002: Terminal graphics — braille for line art, half-blocks for sprites
+
+**Status**: accepted (2026-07)
+
+## Context
+We want expressive visuals (the dino, the mini-game) that survive every
+terminal/font, including phone terminals that render braille and other
+East-Asian-ambiguous glyphs double-wide.
+
+## Decision
+- **Braille (2x4 mono dots)** for the compact header animation: densest
+  portable mode for small line art. Sprite rows contain ONLY braille chars
+  (blanks are U+2800) so width quirks shift whole rows uniformly.
+- **Half-block ▀ PixelCanvas (1x2 full-RGB pixels per cell)** for sprite
+  scenes (the game): color carries more than dot density; ▀ is universal
+  and width-safe. This is the same portable fallback chafa/notcurses use.
+- **No octants** (font support too new) and **no sixel/kitty for now**
+  (terminal-dependent; image placements fight cell-diff renderers) — see
+  issue #94 for the capability-detected future tier.
+- Never place ambiguous-width glyphs (✓ · ❯ arrows) inside bordered boxes;
+  huh forms use a left-accent-bar style with no right edge for this reason.

--- a/docs/adr/0003-release-pipeline.md
+++ b/docs/adr/0003-release-pipeline.md
@@ -1,0 +1,23 @@
+# ADR 0003: semantic-release + goreleaser delivery
+
+**Status**: accepted (2026-07)
+
+## Context
+Releases were broken for months (stale tag collision, publisher id
+mismatches, silent version stamping failure); installs must be one command
+on every OS and self-update safely.
+
+## Decision
+semantic-release computes versions from conventional commits and invokes
+goreleaser. Per-build archives (`standard`/`plus`) because publisher `ids`
+match ARCHIVE ids. Channels: archives, deb/rpm (nfpms), brew tap, scoop
+bucket, AUR, winget — every publisher self-gates with
+`skip_upload: {{ if envOrDefault "SECRET" "" }}auto{{ else }}true{{ end }}`
+so a missing secret can never fail a release. Repository `token`/
+`private_key` fields render in goreleaser's env-only mode: plain
+`{{ .Env.X }}` only, no functions. Self-update (`internal/update`) refuses
+archives that don't match the release's checksums.txt.
+
+## Consequences
+Adding a channel = config + secret; releases are all-or-nothing green.
+`brews` deprecation is accepted until a Linux-capable replacement exists.

--- a/internal/tui/style.go
+++ b/internal/tui/style.go
@@ -1,11 +1,6 @@
 package tui
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	"runtime"
-
 	"charm.land/bubbles/v2/key"
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
@@ -138,32 +133,4 @@ func ConfirmKeyMap() *huh.KeyMap {
 	)
 
 	return km
-}
-
-// ClearScreen clears the terminal screen
-func ClearScreen() {
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.Command("cmd", "/c", "cls")
-	} else {
-		cmd = exec.Command("clear")
-	}
-	cmd.Stdout = os.Stdout
-	_ = cmd.Run()
-}
-
-// RenderHeader renders a consistent header for menus
-func RenderHeader(title string, subtitle string) {
-	fmt.Println(TitleStyle.Render(title))
-	if subtitle != "" {
-		fmt.Println(SubtitleStyle.Render(subtitle))
-	}
-	fmt.Println()
-}
-
-// Pause waits for user input before continuing
-func Pause() {
-	fmt.Println()
-	fmt.Println(lipgloss.NewStyle().Faint(true).Render("Press Enter to continue..."))
-	_, _ = fmt.Scanln()
 }

--- a/internal/tui/style_test.go
+++ b/internal/tui/style_test.go
@@ -1,9 +1,7 @@
 package tui
 
 import (
-	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 )
@@ -127,55 +125,6 @@ func TestConfirmKeyMap(t *testing.T) {
 	submitKeys := km.Confirm.Submit.Keys()
 	if !hasKey(submitKeys, "enter") {
 		t.Errorf("ConfirmKeyMap Submit should bind enter, got: %v", submitKeys)
-	}
-}
-
-// ── RenderHeader tests ───────────────────────────────────────────────────────
-
-func TestRenderHeader(t *testing.T) {
-	// Capture stdout
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	RenderHeader("Test Title", "Test Subtitle")
-
-	_ = w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(r)
-	output := buf.String()
-
-	if !strings.Contains(output, "Test Title") {
-		t.Errorf("RenderHeader output should contain title, got: %s", output)
-	}
-	if !strings.Contains(output, "Test Subtitle") {
-		t.Errorf("RenderHeader output should contain subtitle, got: %s", output)
-	}
-}
-
-func TestRenderHeader_NoSubtitle(t *testing.T) {
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	RenderHeader("Only Title", "")
-
-	_ = w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(r)
-	output := buf.String()
-
-	if !strings.Contains(output, "Only Title") {
-		t.Errorf("RenderHeader output should contain title, got: %s", output)
-	}
-	// Empty subtitle should not produce extra lines
-	lines := strings.Split(strings.TrimSpace(output), "\n")
-	if len(lines) < 1 {
-		t.Error("RenderHeader should produce at least one line of output")
 	}
 }
 


### PR DESCRIPTION
## Review outcomes (code quality / docs / architecture / UX)

**Architecture — one UI codepath.** `bluefin-cli fonts`, `install`, `motd`, `shell`, `starship`, `wallpapers`, and `shell config` now launch the native shell at the right screen (`launchFlow`). The parallel legacy UI — every `run*Menu` function plus the ClearScreen/RenderHeader/Pause helpers — is deleted: **-640 lines**, zero behavior forks between menu and CLI entry.

**Documentation.**
- `CLAUDE.md`: build/test matrix and the landmines (braille width safety, RunnerScreen requirement, goreleaser env-only token fields, viper test isolation, archive-id filters).
- `CONTEXT.md`: domain glossary per org convention.
- `docs/adr/0001-0003`: native shell architecture, terminal graphics strategy, release pipeline design.

**UX.** Interactive commands land inside the shell with esc→Home; Advanced menu copy clarified.

Verified: both variants build, full suite with `-tags extra`, 15/15 tmux smoke, vet, gofmt; tmux-drove `bluefin-cli fonts` → native Fonts screen → esc → Home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fuq6ZMBXZFZKhr4tNvtSNa