### PR TITLE
ci: just verify + goreleaser config guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,28 @@ jobs:
     - name: Run smoke suite
       run: ./scripts/tui-smoke.sh ./bluefin-cli-smoke
 
+  goreleaser-check:
+    name: goreleaser config
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Install GoReleaser
+      uses: goreleaser/goreleaser-action@v7
+      with:
+        version: '~> v2'
+        install-only: true
+
+    # Deprecation warnings (brews) are accepted; hard config errors fail.
+    - name: Check config
+      run: |
+        out=$(goreleaser check 2>&1) && exit 0
+        echo "$out"
+        echo "$out" | grep -q "valid, but uses deprecated" && exit 0
+        exit 1
+
   gofmt:
     name: gofmt
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -305,3 +305,16 @@ tui-smoke:
     go build -tags extra -o tmp/bfc-smoke .
     ./scripts/tui-smoke.sh tmp/bfc-smoke
     rm -f tmp/bfc-smoke
+
+# Full local verification gauntlet — what CI checks, without the queue.
+# GOTMPDIR keeps test binaries off /tmp, which is noexec on some setups.
+verify:
+    mkdir -p tmp/gotmp
+    go build ./...
+    go build -tags extra ./...
+    gofmt -l . | grep -v '^tmp/' | (! grep .) || (echo "gofmt needed" && exit 1)
+    GOTMPDIR=$PWD/tmp/gotmp go vet -tags extra ./...
+    go build -tags extra -o bluefin-cli .
+    GOTMPDIR=$PWD/tmp/gotmp go test -tags extra ./...
+    rm -f bluefin-cli
+    just tui-smoke


### PR DESCRIPTION
- 'just verify' runs everything CI checks (both builds, gofmt, vet, full
  test suite with the integration binary, tmux smoke) without the runner
  queue — the local-first verification path.
- CI gains a goreleaser-check job so config landmines (like the env-only
  token template crash that broke the v0.7.0 publish) are caught on PRs,
  not at release time. Accepted deprecation warnings don't fail it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fuq6ZMBXZFZKhr4tNvtSNa
