### PR TITLE
test: desired-state verification suite (caught 3 real bugs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
     - name: Run smoke suite
       run: ./scripts/tui-smoke.sh ./bluefin-cli-smoke
 
+    - name: Run TUI state suite
+      run: ./scripts/tui-state.sh ./bluefin-cli-smoke
+
   goreleaser-check:
     name: goreleaser config
     runs-on: ubuntu-latest

--- a/cmd/menu.go
+++ b/cmd/menu.go
@@ -142,17 +142,17 @@ func shellMenuScreen() app.Screen {
 	return app.NewMenu("Shell", nil, items, func(it app.MenuItem) tea.Cmd {
 		switch it.Value {
 		case "toggle_current":
+			// Toggling can trigger brew installs (e.g. bash-preexec), which
+			// print — so it must run in a RunnerScreen, never inline.
 			current := currentShellName()
 			enabled := shell.CheckStatus()[current]
-			return tea.Sequence(func() tea.Msg {
-				if err := shell.Toggle(current, !enabled); err != nil {
-					return app.ToastMsg{Text: "Error: " + err.Error(), IsErr: true}
-				}
-				if enabled {
-					return app.ToastMsg{Text: "Shell experience disabled for " + current + "."}
-				}
-				return app.ToastMsg{Text: "Shell experience enabled for " + current + "."}
-			}, app.ReloadTop())
+			verb := "Enabling"
+			if enabled {
+				verb = "Disabling"
+			}
+			return app.Push(app.NewRunner(verb+" "+current, func() error {
+				return shell.Toggle(current, !enabled)
+			}))
 		case "components":
 			return app.Push(componentsFormScreen())
 		case "motd":

--- a/cmd/motd.go
+++ b/cmd/motd.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
 	"github.com/tuna-os/bluefin-cli/internal/motd"
+	"github.com/tuna-os/bluefin-cli/internal/shell"
 	"github.com/tuna-os/bluefin-cli/internal/tui"
 	"github.com/tuna-os/bluefin-cli/internal/tui/app"
 )
@@ -35,7 +37,26 @@ var motdToggleCmd = &cobra.Command{
 			enable = args[1] == "on"
 		}
 
-		return motd.Toggle(target, enable)
+		targets := []string{target}
+		if target == "all" || target == "" {
+			targets = []string{"bash", "zsh", "fish"}
+		}
+		for _, sh := range targets {
+			cfg, err := shell.LoadConfig(sh)
+			if err != nil {
+				cfg = shell.DefaultConfig(sh)
+			}
+			cfg.SetEnabled("Motd", enable)
+			if err := shell.SaveConfig(cfg); err != nil {
+				return fmt.Errorf("saving %s config: %w", sh, err)
+			}
+		}
+		state := "disabled"
+		if enable {
+			state = "enabled"
+		}
+		fmt.Printf("MOTD %s for %s.\n", state, strings.Join(targets, ", "))
+		return nil
 	},
 }
 

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -127,13 +127,11 @@ func MergeBrewfiles(paths []string) (string, func(), error) {
 		return "", func() {}, fmt.Errorf("no brewfiles to merge")
 	}
 
-	tmpDir := os.TempDir()
-	mergedPath := filepath.Join(tmpDir, "merged.Brewfile")
-
-	f, err := os.Create(mergedPath)
+	f, err := os.CreateTemp("", "bluefin-merged-*.Brewfile")
 	if err != nil {
 		return "", func() {}, err
 	}
+	mergedPath := f.Name()
 	defer func() {
 		_ = f.Close()
 	}()

--- a/justfile
+++ b/justfile
@@ -318,3 +318,6 @@ verify:
     GOTMPDIR=$PWD/tmp/gotmp go test -tags extra ./...
     rm -f bluefin-cli
     just tui-smoke
+    go build -tags extra -o tmp/bfc-state .
+    ./scripts/tui-state.sh tmp/bfc-state
+    rm -f tmp/bfc-state

--- a/scripts/tui-state.sh
+++ b/scripts/tui-state.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# TUI end-to-end DESIRED-STATE test: drive the real menu with tmux keys in
+# an isolated HOME and assert the files the UI claims to manage actually
+# changed. Complements tui-smoke.sh (which asserts what's on screen).
+#
+# Usage: scripts/tui-state.sh <binary>
+set -eu
+
+BIN=$(realpath "${1:?usage: tui-state.sh <binary>}")
+SESSION="bfc-state-$$"
+H=$(mktemp -d)
+trap 'tmux kill-session -t "$SESSION" 2>/dev/null || true; rm -rf "$H"' EXIT
+
+mkdir -p "$H/.config"
+printf '# base\n' > "$H/.bashrc"
+
+fail=0
+ok()   { echo "ok   $1"; }
+bad()  { echo "FAIL $1"; fail=1; }
+
+tmux new-session -d -s "$SESSION" -x 100 -y 28
+tmux send-keys -t "$SESSION" "env HOME=$H SHELL=/bin/bash TERM=xterm-256color $BIN menu" Enter
+sleep 2
+
+# Home -> Bluefin Shell (Status, Doctor, Shell) -> toggle current shell on.
+tmux send-keys -t "$SESSION" j; sleep 0.2
+tmux send-keys -t "$SESSION" j; sleep 0.2
+tmux send-keys -t "$SESSION" Enter; sleep 1
+tmux send-keys -t "$SESSION" Enter; sleep 3   # runner: "Enabling bash"
+tmux send-keys -t "$SESSION" Escape; sleep 0.6
+
+grep -q "bluefin-cli init" "$H/.bashrc" \
+  && ok "TUI toggle wrote the init line to .bashrc" \
+  || bad "TUI toggle did not reach .bashrc"
+
+# The menu label must now offer to Disable (state agreement in the UI).
+tmux capture-pane -t "$SESSION" -p | grep -q "Disable for current shell" \
+  && ok "menu label reflects the new state" \
+  || bad "menu label did not refresh after toggle"
+
+# Toggle back off and verify the line is gone but the base content survives.
+tmux send-keys -t "$SESSION" Enter; sleep 3
+tmux send-keys -t "$SESSION" Escape; sleep 0.6
+grep -q "bluefin-cli init" "$H/.bashrc" \
+  && bad "TUI disable left the init line behind" \
+  || ok "TUI disable removed the init line"
+grep -q "# base" "$H/.bashrc" \
+  && ok "pre-existing rc content survived the round trip" \
+  || bad "round trip destroyed pre-existing rc content"
+
+# MOTD toggle through the TUI must land in the shell config JSON.
+tmux send-keys -t "$SESSION" j; sleep 0.2   # Components
+tmux send-keys -t "$SESSION" j; sleep 0.2   # MOTD
+tmux send-keys -t "$SESSION" Enter; sleep 1
+tmux send-keys -t "$SESSION" Enter; sleep 1.5  # toggle MOTD
+if grep -qi '"Motd"' "$H"/.config/bluefin-cli/*.json 2>/dev/null; then
+  ok "TUI MOTD toggle persisted to shell config"
+else
+  bad "TUI MOTD toggle did not persist"
+fi
+
+tmux send-keys -t "$SESSION" Escape; sleep 0.3
+tmux send-keys -t "$SESSION" Escape; sleep 0.3
+tmux send-keys -t "$SESSION" q; sleep 1
+
+if [ "$fail" -eq 0 ]; then
+  echo "TUI state: all checks passed"
+else
+  echo "TUI state: FAILURES"
+  exit 1
+fi

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -140,6 +140,15 @@ func runCommand(t *testing.T, args ...string) (string, error) {
 	return stripAnsi(string(output)), err
 }
 
+// commandWithEnv builds a binary invocation with extra environment entries
+// layered over the current environment (later entries win).
+func commandWithEnv(t *testing.T, extraEnv []string, args ...string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(getBinaryPath(), args...)
+	cmd.Env = append(os.Environ(), extraEnv...)
+	return cmd
+}
+
 func fileContains(t *testing.T, filepath, pattern string) bool {
 	content, err := os.ReadFile(filepath)
 	if err != nil {

--- a/test/state_test.go
+++ b/test/state_test.go
@@ -1,0 +1,159 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/tuna-os/bluefin-cli/internal/shell"
+)
+
+// These tests verify DESIRED STATE, not exit codes: after a command runs,
+// the files it manages must actually contain what the user was promised —
+// and undoing the command must actually undo it.
+
+// TestShellToggleRoundTrip: enabling writes the managed init line, `status`
+// agrees, disabling removes it again, and `status` agrees again.
+func TestShellToggleRoundTrip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shells only")
+	}
+	rc := filepath.Join(os.Getenv("HOME"), ".bashrc")
+	if err := os.WriteFile(rc, []byte("# base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runCommand(t, "shell", "bash", "on"); err != nil {
+		t.Fatalf("enable failed: %v", err)
+	}
+	if !fileContains(t, rc, "bluefin-cli init") {
+		t.Fatal("enable did not write the init line to .bashrc")
+	}
+	out, err := runCommand(t, "status")
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	if !strings.Contains(out, "bash: enabled") {
+		t.Errorf("status disagrees with on-disk state after enable:\n%s", out)
+	}
+
+	if _, err := runCommand(t, "shell", "bash", "off"); err != nil {
+		t.Fatalf("disable failed: %v", err)
+	}
+	if fileContains(t, rc, "bluefin-cli init") {
+		t.Error("disable left the init line in .bashrc")
+	}
+	out, err = runCommand(t, "status")
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	if !strings.Contains(out, "bash: disabled") {
+		t.Errorf("status disagrees with on-disk state after disable:\n%s", out)
+	}
+	// The original content must survive the round trip.
+	if !fileContains(t, rc, "# base") {
+		t.Error("round trip destroyed pre-existing .bashrc content")
+	}
+}
+
+// TestThemeFlavorPersists: `theme <flavor>` must land in config.yaml and
+// read back through the CLI.
+func TestThemeFlavorPersists(t *testing.T) {
+	if _, err := runCommand(t, "theme", "mocha"); err != nil {
+		t.Fatalf("theme set failed: %v", err)
+	}
+	cfg := filepath.Join(os.Getenv("HOME"), ".config", "bluefin-cli", "config.yaml")
+	if !fileContains(t, cfg, "flavor: mocha") {
+		t.Errorf("config.yaml does not contain the chosen flavor")
+	}
+	out, err := runCommand(t, "theme")
+	if err != nil {
+		t.Fatalf("theme read failed: %v", err)
+	}
+	if !strings.Contains(out, "mocha") {
+		t.Errorf("theme readback = %q, want mocha", out)
+	}
+	// Restore auto and verify that persists too.
+	if _, err := runCommand(t, "theme", "auto"); err != nil {
+		t.Fatalf("theme reset failed: %v", err)
+	}
+	if !fileContains(t, cfg, "flavor: auto") {
+		t.Error("resetting to auto did not persist")
+	}
+}
+
+// TestMOTDTogglePersists: `motd toggle <shell> off/on` must be reflected in
+// the shell config the init script consults.
+func TestMOTDTogglePersists(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix shells only")
+	}
+	if _, err := runCommand(t, "motd", "toggle", "bash", "off"); err != nil {
+		t.Fatalf("motd off failed: %v", err)
+	}
+	cfg, err := shell.LoadConfig("bash")
+	if err != nil {
+		t.Fatalf("loading shell config: %v", err)
+	}
+	if cfg.IsEnabled("Motd") {
+		t.Error("motd toggle off did not reach the shell config")
+	}
+
+	if _, err := runCommand(t, "motd", "toggle", "bash", "on"); err != nil {
+		t.Fatalf("motd on failed: %v", err)
+	}
+	cfg, err = shell.LoadConfig("bash")
+	if err != nil {
+		t.Fatalf("loading shell config: %v", err)
+	}
+	if !cfg.IsEnabled("Motd") {
+		t.Error("motd toggle on did not reach the shell config")
+	}
+}
+
+// TestBundleInstallReachesBrew runs `install <bundle>` hermetically with a
+// fake `brew` on PATH that records its argv and the merged Brewfile it was
+// pointed at. Bundles resolve from embedded Brewfiles (offline-first), so
+// this proves the full chain — bundle resolution, merge, brew invocation —
+// delivers real package lines to the package manager.
+func TestBundleInstallReachesBrew(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("brew path is unix-only")
+	}
+
+	fakeBin := t.TempDir()
+	log := filepath.Join(fakeBin, "brew.log")
+	stub := fmt.Sprintf(`#!/bin/sh
+echo "$@" >> %[1]s
+for a in "$@"; do
+  case "$a" in --file=*) cat "${a#--file=}" >> %[1]s ;; esac
+done
+exit 0
+`, log)
+	if err := os.WriteFile(filepath.Join(fakeBin, "brew"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := commandWithEnv(t, []string{
+		"PATH=" + fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}, "install", "cli")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install cli failed: %v\n%s", err, out)
+	}
+
+	logged, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("fake brew was never invoked: %v", err)
+	}
+	got := string(logged)
+	if !strings.Contains(got, "bundle install --file=") {
+		t.Errorf("brew was not asked to install a bundle:\n%s", got)
+	}
+	if !strings.Contains(got, `brew "`) {
+		t.Errorf("no package lines reached brew:\n%s", got)
+	}
+}


### PR DESCRIPTION
New testing layer proving commands REACH the state they promise, not just
exit zero:

- test/state_test.go: shell toggle round-trip (rc line written, status
  agrees, disable removes it, pre-existing content survives), theme flavor
  persistence through config.yaml, motd toggle persistence, and a hermetic
  bundle install with a fake brew on PATH recording the argv and merged
  Brewfile it receives.
- scripts/tui-state.sh: tmux drives the real menu in an isolated HOME and
  asserts the FILES changed — toggle writes/removes the init line, the menu
  label refreshes to match, MOTD lands in shell config. Runs in CI and in
  'just verify'.

Bugs the suite caught, all fixed here:
1. 'motd toggle' was a NO-OP — motd.Toggle printed a note and returned nil.
   The command now writes the Motd flag to the target shells' configs.
2. Merged Brewfiles used the fixed path /tmp/merged.Brewfile — concurrent
   installs clobbered each other. Now os.CreateTemp.
3. The TUI shell toggle ran inline and brew output (bash-preexec install on
   first enable) corrupted the screen — now a RunnerScreen.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fuq6ZMBXZFZKhr4tNvtSNa
