### PR TITLE
fix(release): winget submissions via fork

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -175,11 +175,18 @@ winget:
     # Skip until the WINGET_TOKEN secret is configured, so a missing token
     # can't fail the release.
     skip_upload: '{{ if envOrDefault "WINGET_TOKEN" "" }}auto{{ else }}true{{ end }}'
+    # Submissions to microsoft/winget-pkgs must come from a fork: goreleaser
+    # pushes the manifest branch to the token owner's fork and opens the PR
+    # against upstream (direct branch creation 403s — failed v0.8.0's pipe).
     repository:
-      owner: microsoft
+      owner: hanthor
       name: winget-pkgs
       branch: "bluefin-cli-{{.Version}}"
       token: "{{ .Env.WINGET_TOKEN }}"
       pull_request:
         enabled: true
         draft: false
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master


### PR DESCRIPTION
Direct branch creation on microsoft/winget-pkgs 403s for a PAT — the
supported pattern is push to a fork and PR against upstream. The v0.8.0
release shipped all 17 assets; only this pipe failed. Fork created;
goreleaser now targets it with pull_request.base = microsoft/winget-pkgs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fuq6ZMBXZFZKhr4tNvtSNa
